### PR TITLE
PAAS-524: now use install.yml instead of dx-cluster-universal

### DIFF
--- a/dx-cluster.yml
+++ b/dx-cluster.yml
@@ -159,7 +159,7 @@ onInstall:
   - log: "## using url for universal package: ${globals.url_universal_package}"
 
   - install:
-      jps: ${globals.url_universal_package}/dx-cluster-universal.yml?_r=${fn.random}
+      jps: ${globals.url_universal_package}/install.yml?_r=${fn.random}
       shortdomain: ${settings.shortdomain}
       region: ${settings.envRegion}
       displayName: ${settings.displayname}


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-524

Short description:
now use install.yml instead of dx-cluster-universal